### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-guice)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export MAVEN_PACKAGE="forgerock-guice"
+export BINTRAY_PACKAGE="wrensec-guice"
+export JFROG_PACKAGE="org/forgerock/commons/forgerock-guice"

--- a/forgerock-guice-core/pom.xml
+++ b/forgerock-guice-core/pom.xml
@@ -12,6 +12,7 @@
   information: "Portions Copyrighted [year] [name of copyright owner]".
 
   Copyright 2014 ForgeRock AS.
+  Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -25,8 +26,8 @@
     <artifactId>forgerock-guice-core</artifactId>
     <version>2.0.0</version>
 
-    <name>ForgeRock Guice Core</name>
-    <description>ForgeRock Guice Core Library</description>
+    <name>Wren Security Guice Core</name>
+    <description>Wren Security Guice Core Library</description>
 
     <dependencies>
         <dependency>

--- a/forgerock-guice-core/src/main/java/org/forgerock/guice/core/internal/commons/lang/reflect/ConstructorUtils.java
+++ b/forgerock-guice-core/src/main/java/org/forgerock/guice/core/internal/commons/lang/reflect/ConstructorUtils.java
@@ -17,8 +17,10 @@
  */
 /*
  * Portions Copyright 2014-2015 ForgeRock AS.
- * Copied from commons-lang:commons-lang:2.6 org.apache.commons.lang.reflect.ConstructUtils with un-required methods
- * removed.
+ * Portions Copyright 2017 Wren Security.
+ *
+ * Copied from commons-lang:commons-lang:2.6 org.apache.commons.lang.reflect.ConstructUtils with
+ * un-required methods removed.
  */
 package org.forgerock.guice.core.internal.commons.lang.reflect;
 
@@ -26,7 +28,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
 /**
- * <p> Utility reflection methods focussed on constructors, modelled after {@link MethodUtils}. </p>
+ * Utility reflection methods focussed on constructors, modelled after {@link MemberUtils}.
  *
  * <h3>Known Limitations</h3>
  * <h4>Accessing Public Constructors In A Default Access Superclass</h4>

--- a/forgerock-guice-servlet/pom.xml
+++ b/forgerock-guice-servlet/pom.xml
@@ -13,6 +13,7 @@ Header, with the fields enclosed by brackets [] replaced by your own identifying
 information: "Portions Copyrighted [year] [name of copyright owner]".
 
 Copyright 2014 ForgeRock AS.
+Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -26,8 +27,8 @@ Copyright 2014 ForgeRock AS.
     <artifactId>forgerock-guice-servlet</artifactId>
     <version>2.0.0</version>
 
-    <name>ForgeRock Guice Servlet</name>
-    <description>ForgeRock Guice Servlet Library</description>
+    <name>Wren Security Guice Servlet</name>
+    <description>Wren Security Guice Servlet Library</description>
 
     <dependencies>
         <dependency>
@@ -39,5 +40,4 @@ Copyright 2014 ForgeRock AS.
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
-    
 </project>

--- a/forgerock-guice-test/pom.xml
+++ b/forgerock-guice-test/pom.xml
@@ -13,6 +13,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright 2017 Wren Security.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -27,8 +28,8 @@
     <artifactId>forgerock-guice-test</artifactId>
     <version>2.0.0</version>
 
-    <name>ForgeRock Guice Test</name>
-    <description>ForgeRock Guice Test Library</description>
+    <name>Wren Security Guice Test</name>
+    <description>Wren Security Guice Test Library</description>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@ Header, with the fields enclosed by brackets [] replaced by your own identifying
 information: "Portions Copyrighted [year] [name of copyright owner]".
 
 Copyright 2014-2015 ForgeRock AS.
+Portions Copyright 2017 Wren Security.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -28,9 +29,9 @@ Copyright 2014-2015 ForgeRock AS.
     <version>2.0.0</version>
     <packaging>pom</packaging>
 
-    <name>ForgeRock Guice Library</name>
-    <description>Common Guice implementation used by ForgeRock projects</description>
-    <url>http://commons.forgerock.org/forgerock-guice</url>
+    <name>Wren Security Guice Library</name>
+    <description>Common Guice implementation used by Wren Security forks of ForgeRock projects</description>
+    <url>http://wrensecurity.org/</url>
 
     <licenses>
         <license>
@@ -43,39 +44,29 @@ Copyright 2014-2015 ForgeRock AS.
     </licenses>
 
     <distributionManagement>
-        <site>
-            <id>community.internal.forgerock.com</id>
-            <name>ForgeRock Community</name>
-            <url>scp://community.internal.forgerock.com/var/www/vhosts/commons.forgerock.org/httpdocs/forgerock-guice</url>
-        </site>
+        <snapshotRepository>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-guice/;publish=1</url>
+        </snapshotRepository>
+
+        <repository>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Release Repository</name>
+            <url>${forgerockDistMgmtReleasesUrl}/wrensec-guice/;publish=1</url>
+        </repository>
     </distributionManagement>
 
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/COMMONS</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrensec-guice/issues</url>
     </issueManagement>
 
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-guice.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-guice.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-guice/browse</url>
-        <tag>2.0.0</tag>
+        <url>https://github.com/WrenSecurity/wrensec-guice</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-guice.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-guice.git</developerConnection>
     </scm>
-
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://builds.forgerock.org/job/Commons%20-%20ForgeRock%20Guice%20-%20trunk%20-%20postcommit</url>
-        <notifiers>
-            <notifier>
-                <type>mail</type>
-                <sendOnError>true</sendOnError>
-                <sendOnFailure>true</sendOnFailure>
-                <sendOnSuccess>false</sendOnSuccess>
-                <sendOnWarning>false</sendOnWarning>
-                <address>commons@forgerock.org</address>
-            </notifier>
-        </notifiers>
-    </ciManagement>
 
     <properties>
         <guice.version>4.0</guice.version>
@@ -182,17 +173,28 @@ Copyright 2014-2015 ForgeRock AS.
 
     <repositories>
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
+
         <repository>
-            <id>forgerock-snapshots-repository</id>
-            <name>ForgeRock Snapshot Repository</name>
-            <url>http://maven.forgerock.org/repo/snapshots</url>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
+
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+
             <releases>
                 <enabled>false</enabled>
             </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -45,15 +45,15 @@ Portions Copyright 2017 Wren Security.
 
     <distributionManagement>
         <snapshotRepository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-guice/;publish=1</url>
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
         </snapshotRepository>
 
         <repository>
-            <id>bintray-wrensecurity-snapshots</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}/wrensec-guice/;publish=1</url>
+            <url>${forgerockDistMgmtReleasesUrl}</url>
         </repository>
     </distributionManagement>
 
@@ -172,10 +172,11 @@ Portions Copyright 2017 Wren Security.
     </reporting>
 
     <repositories>
+        <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/releases</url>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
 
             <snapshots>
                 <enabled>false</enabled>
@@ -183,20 +184,6 @@ Portions Copyright 2017 Wren Security.
 
             <releases>
                 <enabled>true</enabled>
-            </releases>
-        </repository>
-
-        <repository>
-            <id>bintray-wrensecurity-snapshots</id>
-            <name>Wren Security Snapshot Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/snapshots</url>
-
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-
-            <releases>
-                <enabled>false</enabled>
             </releases>
         </repository>
     </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,9 @@ Portions Copyright 2017 Wren Security.
     <properties>
         <guice.version>4.0</guice.version>
         <servlet.api.version>3.0.1</servlet.api.version>
+
+        <!-- FIXME: Needed for POM-less com.google.inject:guice:jar:no_aop:3.0 -->
+        <pgpVerifyPluginVersion>1.2.0-SNAPSHOT</pgpVerifyPluginVersion>
     </properties>
 
     <modules>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- corrects issues blocking JavaDoc generation in JDK 8+ (unsupported tags).
- updates branding to call this Wren Security Guice instead of ForgeRock Guice.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.