### PR TITLE
Switches to using pgpverify 1.2.0-wren1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,6 @@ Portions Copyright 2017 Wren Security.
     <properties>
         <guice.version>4.0</guice.version>
         <servlet.api.version>3.0.1</servlet.api.version>
-
-        <!-- FIXME: Needed for POM-less com.google.inject:guice:jar:no_aop:3.0 -->
-        <pgpVerifyPluginVersion>1.2.0-SNAPSHOT</pgpVerifyPluginVersion>
     </properties>
 
     <modules>


### PR DESCRIPTION
The parent POM now defines a release version that works out of the box.