### PR TITLE
Add support for Guice's module override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Major
 
 * Switched to Wren group and artifact ids
+* Added support for module overrides via `GuiceOverride` annotation
 
 
 # 2.0.0

--- a/wrensec-guice-core/src/main/java/org/forgerock/guice/core/GuiceModuleFilter.java
+++ b/wrensec-guice-core/src/main/java/org/forgerock/guice/core/GuiceModuleFilter.java
@@ -1,0 +1,92 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2021 Wren Security.
+ */
+package org.forgerock.guice.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+
+/**
+ * <p>Filtering Guice module instances before they are handed over to Injector.</p>
+ *
+ * <p>
+ * Filter reads {@link GuiceOverride} annotations and applies module overrides.
+ * This allows for simple external overrides of core application components.
+ * </p>
+ *
+ * @since 3.0.0
+ */
+public class GuiceModuleFilter {
+
+    /**
+     * Filter module instances and apply overrides where requested.
+     * @param modules Original module instances.
+     * @return Filtered module instances.
+     */
+    Collection<Module> filter(Collection<Module> modules) {
+        // Make this method deterministic by honoring module order
+        Map<Class<?>, Module> modulesByClass = new LinkedHashMap<>();
+        for (Module module : modules) {
+            modulesByClass.put(module.getClass(), module);
+        }
+        // Build override graph edges
+        Map<Class<?>, Class<?>> classOverrides = new HashMap<>();
+        for (Module module : modules) {
+            Class<?> moduleClass = module.getClass();
+            GuiceOverride annotation = moduleClass.getAnnotation(GuiceOverride.class);
+            if (annotation == null) {
+                continue;
+            }
+            Class<?> overridesClass = annotation.value();
+            if (overridesClass == null || overridesClass == moduleClass) {
+                continue;
+            }
+            // Check if the target module exists
+            if (!modulesByClass.containsKey(overridesClass)) {
+                throw new IllegalArgumentException("Unknown module override for " + moduleClass);
+            }
+            // Switch target class if it is already being overridden
+            if (classOverrides.containsKey(overridesClass)) {
+                overridesClass = classOverrides.get(overridesClass);
+            }
+            classOverrides.put(overridesClass, moduleClass);
+        }
+        // Build the result module collection
+        Collection<Module> finalModules = new ArrayList<>();
+        for (Class<?> moduleClass : modulesByClass.keySet()) {
+            if (moduleClass.getDeclaredAnnotation(GuiceOverride.class) != null) {
+                continue; // Override modules are not part of the final set
+            }
+            Module finalModule = modulesByClass.get(moduleClass);
+            while (true) { // Starting from leaf node so cycles are not possible
+                Class<?> overrideClass = classOverrides.get(moduleClass);
+                if (overrideClass == null) {
+                    break; // No more overrides
+                }
+                moduleClass = overrideClass;
+                finalModule = Modules.override(finalModule).with(modulesByClass.get(overrideClass));
+            }
+            finalModules.add(finalModule);
+        }
+        return finalModules;
+    }
+
+}

--- a/wrensec-guice-core/src/main/java/org/forgerock/guice/core/GuiceOverride.java
+++ b/wrensec-guice-core/src/main/java/org/forgerock/guice/core/GuiceOverride.java
@@ -1,0 +1,41 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2021 Wren Security.
+ */
+package org.forgerock.guice.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.google.inject.Module;
+
+/**
+ * Marks {@link com.google.inject.Module Guice module} class as module override.
+ *
+ * @see com.google.inject.util.Modules#override(Module...)
+ *
+ * @since 1.0.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GuiceOverride {
+
+    /**
+     * This module overrides bindings from the specified module.
+     */
+    Class<? extends Module> value();
+
+}

--- a/wrensec-guice-core/src/main/java/org/forgerock/guice/core/InjectorFactory.java
+++ b/wrensec-guice-core/src/main/java/org/forgerock/guice/core/InjectorFactory.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2021 Wren Security.
  */
 
 package org.forgerock.guice.core;
@@ -39,6 +40,7 @@ final class InjectorFactory {
     private final GuiceModuleCreator moduleCreator;
     private final GuiceInjectorCreator injectorCreator;
     private final GuiceModuleLoader moduleLoader;
+    private final GuiceModuleFilter moduleFilter;
 
     /**
      * Constructs an instance of the InjectorFactory.
@@ -47,11 +49,15 @@ final class InjectorFactory {
      * @param injectorCreator An instance of the GuiceInjectorCreator.
      * @param moduleLoader An instance of the GuiceModuleLoader.
      */
-    InjectorFactory(GuiceModuleCreator moduleCreator, GuiceInjectorCreator injectorCreator,
-            GuiceModuleLoader moduleLoader) {
+    InjectorFactory(
+            GuiceModuleCreator moduleCreator,
+            GuiceInjectorCreator injectorCreator,
+            GuiceModuleLoader moduleLoader,
+            GuiceModuleFilter moduleFilter) {
         this.moduleCreator = moduleCreator;
         this.injectorCreator = injectorCreator;
         this.moduleLoader = moduleLoader;
+        this.moduleFilter = moduleFilter;
     }
 
     /**
@@ -76,19 +82,19 @@ final class InjectorFactory {
      * where all the modules MUST be annotated the given module annotation.
      *
      * @param moduleAnnotation The module annotation.
-     * @return A Set of Guice modules.
+     * @return A collection of Guice modules.
      */
-    @SuppressWarnings("unchecked")
-    private Set<Module> createModules(Class<? extends Annotation> moduleAnnotation) {
+    private Iterable<Module> createModules(Class<? extends Annotation> moduleAnnotation) {
 
         Set<Class<? extends Module>> moduleClasses = moduleLoader.getGuiceModules(moduleAnnotation);
 
-        Set<Module> modules = new HashSet<Module>();
+        Set<Module> modules = new HashSet<>();
 
         for (Class<? extends Module> moduleClass : moduleClasses) {
             modules.add(moduleCreator.createInstance(moduleClass));
         }
 
-        return modules;
+        return moduleFilter.filter(modules);
     }
+
 }

--- a/wrensec-guice-core/src/main/java/org/forgerock/guice/core/InjectorHolder.java
+++ b/wrensec-guice-core/src/main/java/org/forgerock/guice/core/InjectorHolder.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2013-2015 ForgeRock AS.
+ * Portions Copyright 2021 Wren Security.
  */
 
 package org.forgerock.guice.core;
@@ -50,8 +51,11 @@ public enum InjectorHolder {
      * Constructs an instance of the InjectorHolder and initialises the Guice Injector.
      */
     private InjectorHolder() {
-        InjectorFactory injectorFactory = new InjectorFactory(new GuiceModuleCreator(),
-                new GuiceInjectorCreator(), InjectorConfiguration.getGuiceModuleLoader());
+        InjectorFactory injectorFactory = new InjectorFactory(
+                new GuiceModuleCreator(),
+                new GuiceInjectorCreator(),
+                InjectorConfiguration.getGuiceModuleLoader(),
+                new GuiceModuleFilter());
 
         try {
             injector = injectorFactory.createInjector(InjectorConfiguration.getModuleAnnotation());

--- a/wrensec-guice-core/src/test/java/org/forgerock/guice/core/GuiceModuleFilterTest.java
+++ b/wrensec-guice-core/src/test/java/org/forgerock/guice/core/GuiceModuleFilterTest.java
@@ -1,0 +1,139 @@
+/*
+ * The contents of this file are subject to the terms of the Common Development and
+ * Distribution License (the License). You may not use this file except in compliance with the
+ * License.
+ *
+ * You can obtain a copy of the License at legal/CDDLv1.1.txt. See the License for the
+ * specific language governing permission and limitations under the License.
+ *
+ * When distributing Covered Software, include this CDDL Header Notice in each file and include
+ * the License file at legal/CDDLv1.1.txt. If applicable, add the following below the CDDL
+ * Header, with the fields enclosed by brackets [] replaced by your own identifying
+ * information: "Portions copyright [year] [name of copyright owner]".
+ *
+ * Copyright 2021 Wren Security.
+ */
+package org.forgerock.guice.core;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+public class GuiceModuleFilterTest {
+
+    private GuiceModuleFilter moduleFilter = new GuiceModuleFilter();
+
+    @DataProvider
+    public Object[][] validConfig() {
+        return new Object[][] {
+            { "SecondOverride", new Module[] { new RootModule(), new FirstOverride(), new SecondOverride() } },
+            { "SecondOverride", new Module[] { new FirstOverride(), new SecondOverride(), new RootModule() } },
+            { "FirstOverride", new Module[] { new SecondOverride(), new RootModule(), new FirstOverride() } },
+            { "OverrideOverride", new Module[] { new OverrideOverride(), new RootModule(), new FirstOverride() } }
+        };
+    }
+
+    @Test(dataProvider = "validConfig")
+    public void shouldFilterOverridenModules(String expected, Module[] modules) {
+        // Given
+
+        // When
+        Collection<Module> filtered = moduleFilter.filter(Arrays.asList(modules));
+        Injector injector = Guice.createInjector(filtered);
+
+        // Then
+        assertEquals(filtered.size(), 1);
+        assertEquals(injector.getInstance(String.class), expected);
+        assertEquals(injector.getInstance(Integer.class), Integer.valueOf(42));
+    }
+
+    @Test
+    public void shouldNotFilterWithoutOverride() {
+        // Given
+        Collection<Module> modules = Arrays.asList(new StringModule() {}, new StringModule() {});
+
+        // When
+        Collection<Module> filtered = moduleFilter.filter(modules);
+
+        //Then
+        assertEquals(filtered, modules);
+    }
+
+    @DataProvider
+    public Object[][] cycleConfig() {
+        return new Object[][] {
+            new Module[] { new RootModule(), new CycleOverrideA(), new CycleOverrideB() },
+            new Module[] { new RootModule(), new CycleOverrideB(), new CycleOverrideA() },
+            new Module[] { new CycleOverrideA(), new CycleOverrideB(), new RootModule() },
+        };
+    }
+
+    @Test(dataProvider = "cycleConfig")
+    public void shouldIgnoreOverrideOnCycle(Module[] modules) {
+        // Given
+
+        // When
+        Collection<Module> filtered = moduleFilter.filter(Arrays.asList(modules));
+
+        //Then
+        assertEquals(filtered.size(), 1);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, timeOut = 1000)
+    public void shouldThrowExceptionOnInvalidReference() {
+        // Given
+        Collection<Module> modules = Arrays.asList(new FirstOverride());
+
+        // When
+        moduleFilter.filter(modules);
+
+        //Then
+        fail("Invalid reference not detected");
+    }
+
+    static abstract class StringModule extends AbstractModule {
+        @Override
+        protected void configure() {
+            bind(String.class).toInstance(getClass().getSimpleName());
+        }
+    }
+
+    static final class RootModule extends StringModule {
+        @Override
+        protected void configure() {
+            super.configure();
+            bind(Integer.class).toInstance(42);
+        }
+    }
+
+    @GuiceOverride(RootModule.class)
+    static final class FirstOverride extends StringModule {
+    }
+
+    @GuiceOverride(RootModule.class)
+    static final class SecondOverride extends StringModule {
+    }
+
+    @GuiceOverride(FirstOverride.class)
+    static final class OverrideOverride extends StringModule {
+    }
+
+    @GuiceOverride(CycleOverrideB.class)
+    static final class CycleOverrideA extends StringModule {
+    }
+
+    @GuiceOverride(CycleOverrideA.class)
+    static final class CycleOverrideB extends StringModule {
+    }
+
+}

--- a/wrensec-guice-core/src/test/java/org/forgerock/guice/core/InjectorFactoryTest.java
+++ b/wrensec-guice-core/src/test/java/org/forgerock/guice/core/InjectorFactoryTest.java
@@ -12,6 +12,7 @@
 * information: "Portions copyright [year] [name of copyright owner]".
 *
 * Copyright 2013-2015 ForgeRock AS.
+* Portions Copyright 2021 Wren Security.
 */
 
 package org.forgerock.guice.core;
@@ -21,6 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import java.util.HashSet;
@@ -28,6 +30,7 @@ import java.util.Set;
 
 import org.forgerock.guice.core.test.TestModule1;
 import org.forgerock.guice.core.test.TestModule2;
+import org.mockito.AdditionalAnswers;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -41,14 +44,19 @@ public class InjectorFactoryTest {
     private GuiceModuleCreator moduleCreator;
     private GuiceInjectorCreator injectorCreator;
     private GuiceModuleLoader moduleLoader;
+    private GuiceModuleFilter moduleFilter;
 
     @BeforeClass
     public void setUp() {
         moduleCreator = mock(GuiceModuleCreator.class);
         injectorCreator = mock(GuiceInjectorCreator.class);
         moduleLoader = mock(GuiceModuleLoader.class);
+        moduleFilter = mock(GuiceModuleFilter.class);
 
-        injectorFactory = new InjectorFactory(moduleCreator, injectorCreator, moduleLoader);
+        when(moduleFilter.filter(any())).then(AdditionalAnswers.returnsFirstArg());
+
+        injectorFactory = new InjectorFactory(moduleCreator, injectorCreator,
+                moduleLoader, moduleFilter);
     }
 
     @Test

--- a/wrensec-guice-servlet/src/main/java/org/forgerock/guice/core/GuiceInitialisationFilter.java
+++ b/wrensec-guice-servlet/src/main/java/org/forgerock/guice/core/GuiceInitialisationFilter.java
@@ -36,6 +36,7 @@ public final class GuiceInitialisationFilter implements ServletContextListener {
      *
      * @param servletContextEvent {@inheritDoc}
      */
+    @Override
     public void contextInitialized(ServletContextEvent servletContextEvent) {
         ServletContext servletContext = servletContextEvent.getServletContext();
         String stageName = servletContext.getInitParameter(Stage.class.getCanonicalName());
@@ -50,6 +51,7 @@ public final class GuiceInitialisationFilter implements ServletContextListener {
      *
      * @param servletContextEvent {@inheritDoc}
      */
+    @Override
     public void contextDestroyed(ServletContextEvent servletContextEvent) {
     }
 }


### PR DESCRIPTION
This PR adds module override to `InjectorHolder`. Guice modules can be annotated with `@GuiceOverride(TargetModule.class)`. This allows extension developers to add modules that override bindings on existing modules.